### PR TITLE
experimental-webgl to webgl2

### DIFF
--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -132,7 +132,7 @@ function wrap(func) {
 exports.canvas = function() {
     var canvas = document.createElement('canvas');
     try {
-        gl = canvas.getContext('experimental-webgl', { premultipliedAlpha: false });
+        gl = canvas.getContext('webgl2', { premultipliedAlpha: false });
     } catch (e) {
         gl = null;
     }


### PR DESCRIPTION
experimental-webgl is deprecated.

I changed context to use webgl2

Hope this pull request gets accepted.