### PR TITLE
remove `checkFramebufferStatus` call in `texture.js` `drawTo`

### DIFF
--- a/src/core/texture.js
+++ b/src/core/texture.js
@@ -78,9 +78,6 @@ var Texture = (function() {
         gl.framebuffer = gl.framebuffer || gl.createFramebuffer();
         gl.bindFramebuffer(gl.FRAMEBUFFER, gl.framebuffer);
         gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.id, 0);
-        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
-            throw new Error('incomplete framebuffer');
-        }
         gl.viewport(0, 0, this.width, this.height);
 
         // do the drawing


### PR DESCRIPTION
Howdy!

The function call of `checkFramebufferStatus` in `texture.js` takes about 37% of `drawTo` calls on Chrome, by my profiling:

[with_checkFrameBufferStatus.json.zip](https://github.com/evanw/glfx.js/files/8114533/with_checkFrameBufferStatus.json.zip)

On analysis, when `checkFramebufferStatus` returns with something other than `FRAMEBUFFER_COMPLETE`, an error is thrown.

If an error is not manually thrown, an error would still pop-up no? If the if-statement is removed, the only thing lost is a bit of clarity (occasionally, I haven't ever bumped into this issue) for a 40% gain of efficiency.

Simply removing [this](https://github.com/evanw/glfx.js/blob/86ae72acfffcd50774507eb7b69887ba2493dc35/src/core/texture.js#L81-L83) if-statement speeds things up:

[without_getFramebufferStatus.json.zip](https://github.com/evanw/glfx.js/files/8114558/without_getFramebufferStatus.json.zip)

Perhaps I am missing something that `checkFramebufferStatus` does, and if this is the case please let me know!

Cheers, I adore glfx.js!