### PR TITLE
Get viewport dimensions without `gl.getParameter`

### DIFF
--- a/src/core/shader.js
+++ b/src/core/shader.js
@@ -94,11 +94,12 @@ var Shader = (function() {
 
     Shader.prototype.drawRect = function(left, top, right, bottom) {
         var undefined;
-        var viewport = gl.getParameter(gl.VIEWPORT);
-        top = top !== undefined ? (top - viewport[1]) / viewport[3] : 0;
-        left = left !== undefined ? (left - viewport[0]) / viewport[2] : 0;
-        right = right !== undefined ? (right - viewport[0]) / viewport[2] : 1;
-        bottom = bottom !== undefined ? (bottom - viewport[1]) / viewport[3] : 1;
+        // this is (t/l/r/b - viewport minx/miny/maxx/maxy) / (viewport width/hieght/hieght/width)
+        // is top/left/right/botom always 0/0/0/0?
+        top = top !== undefined ? top / gl.drawingBufferHeight : 0;
+        left = left !== undefined ? left / gl.drawingBufferWidth : 0;
+        right = right !== undefined ? right / gl.drawingBufferWidth : 1;
+        bottom = bottom !== undefined ? bottom / gl.drawingBufferWidth : 1;
         if (gl.vertexBuffer == null) {
             gl.vertexBuffer = gl.createBuffer();
         }

--- a/src/core/texture.js
+++ b/src/core/texture.js
@@ -78,9 +78,6 @@ var Texture = (function() {
         gl.framebuffer = gl.framebuffer || gl.createFramebuffer();
         gl.bindFramebuffer(gl.FRAMEBUFFER, gl.framebuffer);
         gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.id, 0);
-        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
-            throw new Error('incomplete framebuffer');
-        }
         gl.viewport(0, 0, this.width, this.height);
 
         // do the drawing


### PR DESCRIPTION
`getParameter` can be slow in webGl because it can potentially require a possible flush + round trip: [Mozilla Docs](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_blocking_api_calls_in_production)

If this is equivalent, removing it increases performance.

edit: draft because I made a mistake with including the previous commit 23bc248 in this PR as well. Leaving it up because I am curious about the response of this.